### PR TITLE
fix ReferenceError in app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 var exec = require('child_process').exec
 var path = require('path')
+var os = require('os')
 var cmd = path.join(__dirname, 'hapticJS', 'DerivedData', 'hapticJS', 'Build', 'Products', 'Release', 'hapticJS')
 
 exports.vibrate = function() {


### PR DESCRIPTION
Current stacktrace from running `hapticjs.vibrate()` on node@16

```
  if (os.platform().includes('darwin')) {
  ^

ReferenceError: os is not defined
```